### PR TITLE
feat: allow monaco editor outside CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,52 @@ export type DecisionTableProps = {
 };
 ```
 
+
+## Self-hosting Monaco Editor
+To self-host monaco editor in Vite.
+
+```ts
+import * as monaco from 'monaco-editor';
+import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
+import cssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker';
+import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker';
+import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker';
+import type { Monaco } from '@monaco-editor/react';
+import { loader } from '@monaco-editor/react';
+
+declare global {
+  interface Window {
+    monaco?: Monaco;
+  }
+}
+
+self.monaco = monaco;
+
+self.MonacoEnvironment = {
+  getWorker(workerId: string, label: string): Promise<Worker> | Worker {
+    if (label === 'json') {
+      return new jsonWorker();
+    }
+    if (label === 'css' || label === 'scss' || label === 'less') {
+      return new cssWorker();
+    }
+    if (label === 'html' || label === 'handlebars' || label === 'razor') {
+      return new htmlWorker();
+    }
+    if (label === 'typescript' || label === 'javascript') {
+      return new tsWorker();
+    }
+
+    return new editorWorker();
+  },
+};
+
+loader.config({ monaco });
+```
+
+For webpack and other configurations, you may require some additional loaders, such as https://www.npmjs.com/package/monaco-editor-webpack-plugin.
+
 ## License
 
 MIT © [GoRules](https://github.com/gorules/jdm-editor/LICENSE)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gorules/jdm-editor",
-  "version": "0.4.0",
+  "version": "0.4.1-beta.1",
   "description": "",
   "author": "GoRules <hi@gorules.io> (https://gorules.io)",
   "homepage": "https://github.com/gorules/jdm-editor",
@@ -36,7 +36,6 @@
   "dependencies": {
     "@ant-design/cssinjs": "1.16.2",
     "@ant-design/icons": "5.2.5",
-    "@monaco-editor/react": "^4.5.2",
     "@tanstack/react-table": "8.9.3",
     "@tanstack/react-virtual": "3.0.0-beta.54",
     "antd": "5.8.4",
@@ -46,7 +45,6 @@
     "graphology": "^0.25.4",
     "graphology-dag": "^0.3.0",
     "immer": "10.0.2",
-    "monaco-editor": "^0.41.0",
     "papaparse": "5.4.1",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "16.0.1",
@@ -58,6 +56,7 @@
     "zustand": "^4.4.1"
   },
   "devDependencies": {
+    "@monaco-editor/react": "^4.6.0",
     "@storybook/addon-actions": "7.3.2",
     "@storybook/addon-docs": "7.3.2",
     "@storybook/addon-essentials": "7.3.2",
@@ -89,6 +88,7 @@
     "eslint-plugin-file-progress": "1.3.0",
     "eslint-plugin-react": "7.33.2",
     "eslint-plugin-react-hooks": "4.6.0",
+    "monaco-editor": "^0.45.0",
     "npm-run-all": "4.1.5",
     "prettier": "3.0.2",
     "react": "18.2.0",
@@ -113,6 +113,8 @@
     ]
   },
   "peerDependencies": {
+    "@monaco-editor/react": ">= 4",
+    "monaco-editor": ">= 0.40",
     "react": ">= 18",
     "react-dom": ">= 18"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gorules/jdm-editor",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "",
   "author": "GoRules <hi@gorules.io> (https://gorules.io)",
   "homepage": "https://github.com/gorules/jdm-editor",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gorules/jdm-editor",
-  "version": "0.4.1-beta.1",
+  "version": "0.4.1-beta.2",
   "description": "",
   "author": "GoRules <hi@gorules.io> (https://gorules.io)",
   "homepage": "https://github.com/gorules/jdm-editor",
@@ -36,6 +36,7 @@
   "dependencies": {
     "@ant-design/cssinjs": "1.16.2",
     "@ant-design/icons": "5.2.5",
+    "@monaco-editor/react": "^4.6.0",
     "@tanstack/react-table": "8.9.3",
     "@tanstack/react-virtual": "3.0.0-beta.54",
     "antd": "5.8.4",
@@ -45,6 +46,7 @@
     "graphology": "^0.25.4",
     "graphology-dag": "^0.3.0",
     "immer": "10.0.2",
+    "monaco-editor": "^0.45.0",
     "papaparse": "5.4.1",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "16.0.1",
@@ -56,7 +58,6 @@
     "zustand": "^4.4.1"
   },
   "devDependencies": {
-    "@monaco-editor/react": "^4.6.0",
     "@storybook/addon-actions": "7.3.2",
     "@storybook/addon-docs": "7.3.2",
     "@storybook/addon-essentials": "7.3.2",
@@ -88,7 +89,6 @@
     "eslint-plugin-file-progress": "1.3.0",
     "eslint-plugin-react": "7.33.2",
     "eslint-plugin-react-hooks": "4.6.0",
-    "monaco-editor": "^0.45.0",
     "npm-run-all": "4.1.5",
     "prettier": "3.0.2",
     "react": "18.2.0",
@@ -113,8 +113,6 @@
     ]
   },
   "peerDependencies": {
-    "@monaco-editor/react": ">= 4",
-    "monaco-editor": ">= 0.40",
     "react": ">= 18",
     "react-dom": ">= 18"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gorules/jdm-editor",
-  "version": "0.4.1-beta.2",
+  "version": "0.4.1",
   "description": "",
   "author": "GoRules <hi@gorules.io> (https://gorules.io)",
   "homepage": "https://github.com/gorules/jdm-editor",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   enhanced-resolve: 5.10.0
 
@@ -10,9 +14,6 @@ dependencies:
   '@ant-design/icons':
     specifier: 5.2.5
     version: 5.2.5(react-dom@18.2.0)(react@18.2.0)
-  '@monaco-editor/react':
-    specifier: ^4.5.2
-    version: 4.5.2(monaco-editor@0.41.0)(react-dom@18.2.0)(react@18.2.0)
   '@tanstack/react-table':
     specifier: 8.9.3
     version: 8.9.3(react-dom@18.2.0)(react@18.2.0)
@@ -40,9 +41,6 @@ dependencies:
   immer:
     specifier: 10.0.2
     version: 10.0.2
-  monaco-editor:
-    specifier: ^0.41.0
-    version: 0.41.0
   papaparse:
     specifier: 5.4.1
     version: 5.4.1
@@ -72,6 +70,9 @@ dependencies:
     version: 4.4.1(@types/react@18.2.21)(immer@10.0.2)(react@18.2.0)
 
 devDependencies:
+  '@monaco-editor/react':
+    specifier: ^4.6.0
+    version: 4.6.0(monaco-editor@0.45.0)(react-dom@18.2.0)(react@18.2.0)
   '@storybook/addon-actions':
     specifier: 7.3.2
     version: 7.3.2(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
@@ -165,6 +166,9 @@ devDependencies:
   eslint-plugin-react-hooks:
     specifier: 4.6.0
     version: 4.6.0(eslint@8.47.0)
+  monaco-editor:
+    specifier: ^0.45.0
+    version: 0.45.0
   npm-run-all:
     specifier: 4.1.5
     version: 4.1.5
@@ -2450,27 +2454,27 @@ packages:
     resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
     dev: true
 
-  /@monaco-editor/loader@1.3.3(monaco-editor@0.41.0):
-    resolution: {integrity: sha512-6KKF4CTzcJiS8BJwtxtfyYt9shBiEv32ateQ9T4UVogwn4HM/uPo9iJd2Dmbkpz8CM6Y0PDUpjnZzCwC+eYo2Q==}
+  /@monaco-editor/loader@1.4.0(monaco-editor@0.45.0):
+    resolution: {integrity: sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==}
     peerDependencies:
       monaco-editor: '>= 0.21.0 < 1'
     dependencies:
-      monaco-editor: 0.41.0
+      monaco-editor: 0.45.0
       state-local: 1.0.7
-    dev: false
+    dev: true
 
-  /@monaco-editor/react@4.5.2(monaco-editor@0.41.0)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-emcWu6vg1OpXPiYll4aPOaXe8bwYB4UaaNTwtArFLgMoNGBzRZb2Xn0Bra2HMIFM7QLgs7fCGunHO5LkfT2LBA==}
+  /@monaco-editor/react@4.6.0(monaco-editor@0.45.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==}
     peerDependencies:
       monaco-editor: '>= 0.25.0 < 1'
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@monaco-editor/loader': 1.3.3(monaco-editor@0.41.0)
-      monaco-editor: 0.41.0
+      '@monaco-editor/loader': 1.4.0(monaco-editor@0.45.0)
+      monaco-editor: 0.45.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
+    dev: true
 
   /@ndelangen/get-tarball@3.0.7:
     resolution: {integrity: sha512-NqGfTZIZpRFef1GoVaShSSRwDC3vde3ThtTeqFdcYd6ipKqnfEVhjK2hUeHjCQUcptyZr2TONqcloFXM+5QBrQ==}
@@ -8863,9 +8867,9 @@ packages:
       obliterator: 2.0.4
     dev: false
 
-  /monaco-editor@0.41.0:
-    resolution: {integrity: sha512-1o4olnZJsiLmv5pwLEAmzHTE/5geLKQ07BrGxlF4Ri/AXAc2yyDGZwHjiTqD8D/ROKUZmwMA28A+yEowLNOEcA==}
-    dev: false
+  /monaco-editor@0.45.0:
+    resolution: {integrity: sha512-mjv1G1ZzfEE3k9HZN0dQ2olMdwIfaeAAjFiwNprLfYNRSz7ctv9XuCT7gPtBGrMUeV1/iZzYKj17Khu1hxoHOA==}
+    dev: true
 
   /mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -10913,7 +10917,7 @@ packages:
 
   /state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
-    dev: false
+    dev: true
 
   /statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
@@ -12007,7 +12011,3 @@ packages:
       react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   '@ant-design/icons':
     specifier: 5.2.5
     version: 5.2.5(react-dom@18.2.0)(react@18.2.0)
+  '@monaco-editor/react':
+    specifier: ^4.6.0
+    version: 4.6.0(monaco-editor@0.45.0)(react-dom@18.2.0)(react@18.2.0)
   '@tanstack/react-table':
     specifier: 8.9.3
     version: 8.9.3(react-dom@18.2.0)(react@18.2.0)
@@ -41,6 +44,9 @@ dependencies:
   immer:
     specifier: 10.0.2
     version: 10.0.2
+  monaco-editor:
+    specifier: ^0.45.0
+    version: 0.45.0
   papaparse:
     specifier: 5.4.1
     version: 5.4.1
@@ -70,9 +76,6 @@ dependencies:
     version: 4.4.1(@types/react@18.2.21)(immer@10.0.2)(react@18.2.0)
 
 devDependencies:
-  '@monaco-editor/react':
-    specifier: ^4.6.0
-    version: 4.6.0(monaco-editor@0.45.0)(react-dom@18.2.0)(react@18.2.0)
   '@storybook/addon-actions':
     specifier: 7.3.2
     version: 7.3.2(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
@@ -166,9 +169,6 @@ devDependencies:
   eslint-plugin-react-hooks:
     specifier: 4.6.0
     version: 4.6.0(eslint@8.47.0)
-  monaco-editor:
-    specifier: ^0.45.0
-    version: 0.45.0
   npm-run-all:
     specifier: 4.1.5
     version: 4.1.5
@@ -2461,7 +2461,7 @@ packages:
     dependencies:
       monaco-editor: 0.45.0
       state-local: 1.0.7
-    dev: true
+    dev: false
 
   /@monaco-editor/react@4.6.0(monaco-editor@0.45.0)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==}
@@ -2474,7 +2474,7 @@ packages:
       monaco-editor: 0.45.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@ndelangen/get-tarball@3.0.7:
     resolution: {integrity: sha512-NqGfTZIZpRFef1GoVaShSSRwDC3vde3ThtTeqFdcYd6ipKqnfEVhjK2hUeHjCQUcptyZr2TONqcloFXM+5QBrQ==}
@@ -8869,7 +8869,7 @@ packages:
 
   /monaco-editor@0.45.0:
     resolution: {integrity: sha512-mjv1G1ZzfEE3k9HZN0dQ2olMdwIfaeAAjFiwNprLfYNRSz7ctv9XuCT7gPtBGrMUeV1/iZzYKj17Khu1hxoHOA==}
-    dev: true
+    dev: false
 
   /mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -10917,7 +10917,7 @@ packages:
 
   /state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
-    dev: true
+    dev: false
 
   /statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}

--- a/src/components/function/function.tsx
+++ b/src/components/function/function.tsx
@@ -9,6 +9,7 @@ import { Stack } from '../stack';
 import { FunctionDebugger } from './function-debugger';
 import './function.scss';
 import { functionDefinitions } from './helpers/libs';
+import './monaco';
 import type { FunctionDebuggerTrace } from './types';
 
 export type FunctionProps = {

--- a/src/components/function/monaco.ts
+++ b/src/components/function/monaco.ts
@@ -1,0 +1,12 @@
+import type { Monaco } from '@monaco-editor/react';
+import { loader } from '@monaco-editor/react';
+
+declare global {
+  interface Window {
+    monaco?: Monaco;
+  }
+}
+
+if (self.monaco) {
+  loader.config({ monaco: self.monaco });
+}


### PR DESCRIPTION
This MR allows custom hosting of Monaco Editor, by defining language workers in host application. Example file:

```ts
import * as monaco from 'monaco-editor';
import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
import cssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker';
import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker';
import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker';
import type { Monaco } from '@monaco-editor/react';
import { loader } from '@monaco-editor/react';

declare global {
  interface Window {
    monaco?: Monaco;
  }
}

self.monaco = monaco;

self.MonacoEnvironment = {
  getWorker(workerId: string, label: string): Promise<Worker> | Worker {
    if (label === 'json') {
      return new jsonWorker();
    }
    if (label === 'css' || label === 'scss' || label === 'less') {
      return new cssWorker();
    }
    if (label === 'html' || label === 'handlebars' || label === 'razor') {
      return new htmlWorker();
    }
    if (label === 'typescript' || label === 'javascript') {
      return new tsWorker();
    }

    return new editorWorker();
  },
};

loader.config({ monaco });

```