### PR TITLE
feat: allow custom tabs

### DIFF
--- a/packages/jdm-editor/src/components/decision-graph/context/dg-store.context.tsx
+++ b/packages/jdm-editor/src/components/decision-graph/context/dg-store.context.tsx
@@ -11,6 +11,8 @@ import type { useGraphClipboard } from '../hooks/use-graph-clipboard';
 import type { CustomNodeSpecification } from '../nodes/custom-node/index';
 import { NodeKind, type NodeSpecification } from '../nodes/specifications/specification-types';
 import type { Simulation } from '../types/simulation.types';
+import { BASE_TABS, type Tab } from '../graph/common-tab';
+
 
 export type Position = {
   x: number;
@@ -63,6 +65,7 @@ export type DecisionGraphStoreType = {
     activeTab: string;
 
     customNodes: CustomNodeSpecification<object, string>[];
+    customTabs: Tab[];
 
     panels?: PanelType[];
     activePanel?: string;
@@ -141,6 +144,9 @@ export const DecisionGraphProvider: React.FC<React.PropsWithChildren<DecisionGra
         configurable: true,
         components: [],
         customNodes: [],
+        customTabs: [
+          ...BASE_TABS
+        ],
         activePanel: undefined,
         panels: [],
       })),

--- a/packages/jdm-editor/src/components/decision-graph/context/dg-store.context.tsx
+++ b/packages/jdm-editor/src/components/decision-graph/context/dg-store.context.tsx
@@ -7,12 +7,11 @@ import type { StoreApi, UseBoundStore } from 'zustand';
 import { create } from 'zustand';
 
 import { mapToGraphEdge, mapToGraphEdges, mapToGraphNode, mapToGraphNodes } from '../dg-util';
+import { BASE_TABS, type Tab } from '../graph/common-tab';
 import type { useGraphClipboard } from '../hooks/use-graph-clipboard';
 import type { CustomNodeSpecification } from '../nodes/custom-node/index';
 import { NodeKind, type NodeSpecification } from '../nodes/specifications/specification-types';
 import type { Simulation } from '../types/simulation.types';
-import { BASE_TABS, type Tab } from '../graph/common-tab';
-
 
 export type Position = {
   x: number;
@@ -144,9 +143,7 @@ export const DecisionGraphProvider: React.FC<React.PropsWithChildren<DecisionGra
         configurable: true,
         components: [],
         customNodes: [],
-        customTabs: [
-          ...BASE_TABS
-        ],
+        customTabs: [...BASE_TABS],
         activePanel: undefined,
         panels: [],
       })),

--- a/packages/jdm-editor/src/components/decision-graph/dg-empty.tsx
+++ b/packages/jdm-editor/src/components/decision-graph/dg-empty.tsx
@@ -21,7 +21,7 @@ export type DecisionGraphEmptyType = {
 
   components?: DecisionGraphStoreType['state']['components'];
   customNodes?: DecisionGraphStoreType['state']['customNodes'];
-  customTabs?: DecisionGraphStoreType['state']['customTabs']
+  customTabs?: DecisionGraphStoreType['state']['customTabs'];
 
   defaultActivePanel?: string;
   panels?: DecisionGraphStoreType['state']['panels'];
@@ -52,9 +52,9 @@ export const DecisionGraphEmpty: React.FC<DecisionGraphEmptyType> = ({
   const mountedRef = useRef(false);
   const graphActions = useDecisionGraphActions();
   const { stateStore, listenerStore } = useDecisionGraphRaw();
-  const { decisionGraph,tabs } = useDecisionGraphState(({ decisionGraph, customTabs }) => ({
+  const { decisionGraph, tabs } = useDecisionGraphState(({ decisionGraph, customTabs }) => ({
     decisionGraph,
-    tabs: customTabs
+    tabs: customTabs,
   }));
 
   const innerChange = useDebouncedCallback((graph: DecisionGraphType) => {

--- a/packages/jdm-editor/src/components/decision-graph/dg-empty.tsx
+++ b/packages/jdm-editor/src/components/decision-graph/dg-empty.tsx
@@ -21,6 +21,7 @@ export type DecisionGraphEmptyType = {
 
   components?: DecisionGraphStoreType['state']['components'];
   customNodes?: DecisionGraphStoreType['state']['customNodes'];
+  customTabs?: DecisionGraphStoreType['state']['customTabs']
 
   defaultActivePanel?: string;
   panels?: DecisionGraphStoreType['state']['panels'];
@@ -41,6 +42,7 @@ export const DecisionGraphEmpty: React.FC<DecisionGraphEmptyType> = ({
   onChange,
   components,
   customNodes,
+  customTabs,
   defaultActivePanel,
   panels,
   simulate,
@@ -50,8 +52,9 @@ export const DecisionGraphEmpty: React.FC<DecisionGraphEmptyType> = ({
   const mountedRef = useRef(false);
   const graphActions = useDecisionGraphActions();
   const { stateStore, listenerStore } = useDecisionGraphRaw();
-  const { decisionGraph } = useDecisionGraphState(({ decisionGraph }) => ({
+  const { decisionGraph,tabs } = useDecisionGraphState(({ decisionGraph, customTabs }) => ({
     decisionGraph,
+    tabs: customTabs
   }));
 
   const innerChange = useDebouncedCallback((graph: DecisionGraphType) => {
@@ -65,6 +68,7 @@ export const DecisionGraphEmpty: React.FC<DecisionGraphEmptyType> = ({
       configurable,
       components: Array.isArray(components) ? components : [],
       customNodes: Array.isArray(customNodes) ? customNodes : [],
+      customTabs: Array.isArray(customTabs) ? [...tabs, ...customTabs] : tabs,
       panels,
     });
   }, [id, disabled, configurable, components, customNodes, panels]);

--- a/packages/jdm-editor/src/components/decision-graph/dg-wrapper.tsx
+++ b/packages/jdm-editor/src/components/decision-graph/dg-wrapper.tsx
@@ -12,9 +12,6 @@ import type { GraphRef } from './graph/graph';
 import { Graph } from './graph/graph';
 import { GraphAside, type GraphAsideProps } from './graph/graph-aside';
 import { GraphTabs } from './graph/graph-tabs';
-import { TabDecisionTable } from './graph/tab-decision-table';
-import { TabExpression } from './graph/tab-expression';
-import { TabFunction } from './graph/tab-function';
 
 export type DecisionGraphWrapperProps = {
   reactFlowProOptions?: ProOptions;
@@ -48,13 +45,14 @@ export const DecisionGraphWrapper = React.memo(
 );
 
 const TabContents: React.FC = React.memo(() => {
-  const { openNodes, activeNodeId } = useDecisionGraphState(({ decisionGraph, openTabs, activeTab }) => {
+  const { openNodes, activeNodeId, tabs } = useDecisionGraphState(({ decisionGraph, openTabs, activeTab, customTabs }) => {
     const activeNodeId = (decisionGraph?.nodes ?? []).find((node) => node.id === activeTab)?.id;
     const openNodes = (decisionGraph?.nodes ?? []).filter((node) => openTabs.includes(node.id));
 
     return {
       openNodes: openNodes.map(({ id, type }) => ({ id, type })),
       activeNodeId,
+      tabs: customTabs
     };
   });
 
@@ -69,9 +67,7 @@ const TabContents: React.FC = React.memo(() => {
     <div style={{ display: 'contents' }} ref={containerRef}>
       {openNodes.map((node) => (
         <div key={node?.id} className={clsx(['tab-content', activeNodeId === node?.id && 'active'])}>
-          {node?.type === 'decisionTableNode' && <TabDecisionTable id={node.id} manager={dndManager} />}
-          {node?.type === 'expressionNode' && <TabExpression id={node.id} manager={dndManager} />}
-          {node?.type === 'functionNode' && <TabFunction id={node.id} />}
+          {tabs.find(tab => tab.type === node?.type)?.tab({id: node.id, manager: dndManager})}
         </div>
       ))}
     </div>

--- a/packages/jdm-editor/src/components/decision-graph/dg-wrapper.tsx
+++ b/packages/jdm-editor/src/components/decision-graph/dg-wrapper.tsx
@@ -45,16 +45,18 @@ export const DecisionGraphWrapper = React.memo(
 );
 
 const TabContents: React.FC = React.memo(() => {
-  const { openNodes, activeNodeId, tabs } = useDecisionGraphState(({ decisionGraph, openTabs, activeTab, customTabs }) => {
-    const activeNodeId = (decisionGraph?.nodes ?? []).find((node) => node.id === activeTab)?.id;
-    const openNodes = (decisionGraph?.nodes ?? []).filter((node) => openTabs.includes(node.id));
+  const { openNodes, activeNodeId, tabs } = useDecisionGraphState(
+    ({ decisionGraph, openTabs, activeTab, customTabs }) => {
+      const activeNodeId = (decisionGraph?.nodes ?? []).find((node) => node.id === activeTab)?.id;
+      const openNodes = (decisionGraph?.nodes ?? []).filter((node) => openTabs.includes(node.id));
 
-    return {
-      openNodes: openNodes.map(({ id, type }) => ({ id, type })),
-      activeNodeId,
-      tabs: customTabs
-    };
-  });
+      return {
+        openNodes: openNodes.map(({ id, type }) => ({ id, type })),
+        activeNodeId,
+        tabs: customTabs,
+      };
+    },
+  );
 
   const containerRef = useRef<HTMLDivElement>(null);
   const dndManager = useMemo(() => {
@@ -67,7 +69,7 @@ const TabContents: React.FC = React.memo(() => {
     <div style={{ display: 'contents' }} ref={containerRef}>
       {openNodes.map((node) => (
         <div key={node?.id} className={clsx(['tab-content', activeNodeId === node?.id && 'active'])}>
-          {tabs.find(tab => tab.type === node?.type)?.tab({id: node.id, manager: dndManager})}
+          {tabs.find((tab) => tab.type === node?.type)?.tab({ id: node.id, manager: dndManager })}
         </div>
       ))}
     </div>

--- a/packages/jdm-editor/src/components/decision-graph/dg.stories.tsx
+++ b/packages/jdm-editor/src/components/decision-graph/dg.stories.tsx
@@ -4,15 +4,15 @@ import { Button, Select } from 'antd';
 import json5 from 'json5';
 import React, { useRef, useState } from 'react';
 
-import { useDecisionGraphActions, type PanelType } from './context/dg-store.context';
+import { type PanelType, useDecisionGraphActions } from './context/dg-store.context';
 import { DecisionGraph } from './dg';
 import { GraphSimulator } from './dg-simulator';
 import { defaultGraph, defaultGraphCustomNode, defaultGraphUnknownNode } from './dg.stories-values';
+import type { Tab } from './graph/common-tab';
 import type { GraphRef } from './graph/graph';
 import { createJdmNode } from './nodes/custom-node';
 import { GraphNode } from './nodes/graph-node';
 import type { NodeSpecification } from './nodes/specifications/specification-types';
-import type { Tab } from './graph/common-tab';
 
 const meta: Meta<typeof DecisionGraph> = {
   /* 👇 The title prop is optional.
@@ -114,23 +114,41 @@ const customTabsComponents: NodeSpecification[] = [
     renderNode: ({ specification, id, selected, data }) => {
       const graphActions = useDecisionGraphActions();
       return (
-      <GraphNode id={id} specification={specification} name={data.name} isSelected={selected} actions={[<Button key='edit-table' type='link' onClick={() => graphActions.openTab(id)}>
-      Edit Table
-    </Button>]}>
-       
-      </GraphNode>
-    )},
+        <GraphNode
+          id={id}
+          specification={specification}
+          name={data.name}
+          isSelected={selected}
+          actions={[
+            <Button key='edit-table' type='link' onClick={() => graphActions.openTab(id)}>
+              Edit Table
+            </Button>,
+          ]}
+        ></GraphNode>
+      );
+    },
   },
 ];
 
-const customTabs: Tab[] = [{type: "decisionNode", tab: ({id}) => {
-  const graphActions = useDecisionGraphActions();
+const customTabs: Tab[] = [
+  {
+    type: 'decisionNode',
+    tab: ({ id }) => {
+      const graphActions = useDecisionGraphActions();
 
-  return <input onChange={(e) => graphActions.updateNode(id, (draft) => {
-    draft.content = e.target.value;
-    return draft;
-  })}></input>
-}}]
+      return (
+        <input
+          onChange={(e) =>
+            graphActions.updateNode(id, (draft) => {
+              draft.content = e.target.value;
+              return draft;
+            })
+          }
+        ></input>
+      );
+    },
+  },
+];
 
 export const CustomTab: Story = {
   render: (args) => {
@@ -143,7 +161,14 @@ export const CustomTab: Story = {
           height: '100%',
         }}
       >
-        <DecisionGraph {...args} ref={ref} value={value} onChange={(val) => setValue(val)} components={customTabsComponents} customTabs={customTabs}/>
+        <DecisionGraph
+          {...args}
+          ref={ref}
+          value={value}
+          onChange={(val) => setValue(val)}
+          components={customTabsComponents}
+          customTabs={customTabs}
+        />
       </div>
     );
   },

--- a/packages/jdm-editor/src/components/decision-graph/dg.stories.tsx
+++ b/packages/jdm-editor/src/components/decision-graph/dg.stories.tsx
@@ -1,10 +1,10 @@
 import { ApartmentOutlined, ApiOutlined, LeftOutlined, PlayCircleOutlined, RightOutlined } from '@ant-design/icons';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Select } from 'antd';
+import { Button, Select } from 'antd';
 import json5 from 'json5';
 import React, { useRef, useState } from 'react';
 
-import type { PanelType } from './context/dg-store.context';
+import { useDecisionGraphActions, type PanelType } from './context/dg-store.context';
 import { DecisionGraph } from './dg';
 import { GraphSimulator } from './dg-simulator';
 import { defaultGraph, defaultGraphCustomNode, defaultGraphUnknownNode } from './dg.stories-values';
@@ -12,6 +12,7 @@ import type { GraphRef } from './graph/graph';
 import { createJdmNode } from './nodes/custom-node';
 import { GraphNode } from './nodes/graph-node';
 import type { NodeSpecification } from './nodes/specifications/specification-types';
+import type { Tab } from './graph/common-tab';
 
 const meta: Meta<typeof DecisionGraph> = {
   /* 👇 The title prop is optional.
@@ -98,6 +99,51 @@ export const Extended: Story = {
         }}
       >
         <DecisionGraph {...args} ref={ref} value={value} onChange={(val) => setValue(val)} components={components} />
+      </div>
+    );
+  },
+};
+
+const customTabsComponents: NodeSpecification[] = [
+  {
+    type: 'decisionNode',
+    displayName: 'Decision',
+    shortDescription: 'Execute decisions',
+    icon: <ApartmentOutlined />,
+    generateNode: () => ({ name: 'myDecision' }),
+    renderNode: ({ specification, id, selected, data }) => {
+      const graphActions = useDecisionGraphActions();
+      return (
+      <GraphNode id={id} specification={specification} name={data.name} isSelected={selected} actions={[<Button key='edit-table' type='link' onClick={() => graphActions.openTab(id)}>
+      Edit Table
+    </Button>]}>
+       
+      </GraphNode>
+    )},
+  },
+];
+
+const customTabs: Tab[] = [{type: "decisionNode", tab: ({id}) => {
+  const graphActions = useDecisionGraphActions();
+
+  return <input onChange={(e) => graphActions.updateNode(id, (draft) => {
+    draft.content = e.target.value;
+    return draft;
+  })}></input>
+}}]
+
+export const CustomTab: Story = {
+  render: (args) => {
+    const ref = useRef<GraphRef>(null);
+    const [value, setValue] = useState<any>();
+
+    return (
+      <div
+        style={{
+          height: '100%',
+        }}
+      >
+        <DecisionGraph {...args} ref={ref} value={value} onChange={(val) => setValue(val)} components={customTabsComponents} customTabs={customTabs}/>
       </div>
     );
   },

--- a/packages/jdm-editor/src/components/decision-graph/graph/common-tab.tsx
+++ b/packages/jdm-editor/src/components/decision-graph/graph/common-tab.tsx
@@ -1,0 +1,16 @@
+import type { DragDropManager  } from "dnd-core";
+import { TabDecisionTable } from "./tab-decision-table";
+import { TabExpression } from "./tab-expression";
+import { TabFunction } from "./tab-function";
+import { type ReactNode } from "react";
+
+export type Tab = {type: string; tab: (p: CommonTabProps) => ReactNode }
+
+export type CommonTabProps = {
+  id: string;
+  manager?: DragDropManager;
+}
+
+export const BASE_TABS: Tab[] = [{type: "decisionTableNode", tab: (p) =>  <TabDecisionTable {...p} />}, 
+{type: "expressionNode", tab: (p) => <TabExpression {...p} />},
+{type: "functionNode", tab: (p) => <TabFunction {...p} />}] as const;

--- a/packages/jdm-editor/src/components/decision-graph/graph/common-tab.tsx
+++ b/packages/jdm-editor/src/components/decision-graph/graph/common-tab.tsx
@@ -1,16 +1,19 @@
-import type { DragDropManager  } from "dnd-core";
-import { TabDecisionTable } from "./tab-decision-table";
-import { TabExpression } from "./tab-expression";
-import { TabFunction } from "./tab-function";
-import { type ReactNode } from "react";
+import type { DragDropManager } from 'dnd-core';
+import { type ReactNode } from 'react';
 
-export type Tab = {type: string; tab: (p: CommonTabProps) => ReactNode }
+import { TabDecisionTable } from './tab-decision-table';
+import { TabExpression } from './tab-expression';
+import { TabFunction } from './tab-function';
+
+export type Tab = { type: string; tab: (p: CommonTabProps) => ReactNode };
 
 export type CommonTabProps = {
   id: string;
   manager?: DragDropManager;
-}
+};
 
-export const BASE_TABS: Tab[] = [{type: "decisionTableNode", tab: (p) =>  <TabDecisionTable {...p} />}, 
-{type: "expressionNode", tab: (p) => <TabExpression {...p} />},
-{type: "functionNode", tab: (p) => <TabFunction {...p} />}] as const;
+export const BASE_TABS: Tab[] = [
+  { type: 'decisionTableNode', tab: (p) => <TabDecisionTable {...p} /> },
+  { type: 'expressionNode', tab: (p) => <TabExpression {...p} /> },
+  { type: 'functionNode', tab: (p) => <TabFunction {...p} /> },
+] as const;


### PR DESCRIPTION
This PR adds support for custom tabs following this type:
```typescript
export type Tab = { type: string; tab: (p: CommonTabProps) => ReactNode };
```
`type` being the Node type that should be updated.

I also added a story for this.

Should fix #49 .