### PR TITLE
Fix blinking on hover and add better exports for esm

### DIFF
--- a/packages/jdm-editor/CHANGELOG.md
+++ b/packages/jdm-editor/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.23.2](https://github.com/nimbit-software/jdm-editor/compare/@gorules/jdm-editor@1.23.1...@gorules/jdm-editor@1.23.2) (2024-10-31)
+
+**Note:** Version bump only for package @gorules/jdm-editor
+
 ## [1.23.1](https://github.com/gorules/jdm-editor/compare/@gorules/jdm-editor@1.23.0...@gorules/jdm-editor@1.23.1) (2024-10-30)
 
 ### Bug Fixes

--- a/packages/jdm-editor/CHANGELOG.md
+++ b/packages/jdm-editor/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.23.2](https://github.com/nimbit-software/jdm-editor/compare/@gorules/jdm-editor@1.23.1...@gorules/jdm-editor@1.23.2) (2024-10-31)
-
-**Note:** Version bump only for package @gorules/jdm-editor
-
 ## [1.23.1](https://github.com/gorules/jdm-editor/compare/@gorules/jdm-editor@1.23.0...@gorules/jdm-editor@1.23.1) (2024-10-30)
 
 ### Bug Fixes

--- a/packages/jdm-editor/package.json
+++ b/packages/jdm-editor/package.json
@@ -7,8 +7,9 @@
   "license": "MIT",
   "keywords": [],
   "type": "module",
-  "main": "dist/jdm-editor.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist/",
     "package.json",

--- a/packages/jdm-editor/package.json
+++ b/packages/jdm-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gorules/jdm-editor",
-  "version": "1.23.2",
+  "version": "1.23.1",
   "description": "",
   "author": "GoRules <hi@gorules.io> (https://gorules.io)",
   "homepage": "https://github.com/gorules/jdm-editor",

--- a/packages/jdm-editor/package.json
+++ b/packages/jdm-editor/package.json
@@ -17,14 +17,19 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": "./dist/index.js"
     },
-    "./dist/schema": {
-      "import": "./dist/schema.js",
-      "types": "./dist/schema.d.ts"
+    "./schema": {
+      "types": "./dist/schema.d.ts",
+      "require": "./dist/schema.js",
+      "import": "./dist/schema.js"
     },
-    "./dist/style.css": "./dist/style.css"
+    "./style.css": {
+      "import": "./dist/style.css",
+      "require": "./dist/style.css"
+    }
   },
   "scripts": {
     "build": "vite build",

--- a/packages/jdm-editor/package.json
+++ b/packages/jdm-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gorules/jdm-editor",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "description": "",
   "author": "GoRules <hi@gorules.io> (https://gorules.io)",
   "homepage": "https://github.com/gorules/jdm-editor",

--- a/packages/jdm-editor/src/components/decision-graph/dg-panel.tsx
+++ b/packages/jdm-editor/src/components/decision-graph/dg-panel.tsx
@@ -23,7 +23,7 @@ export const GraphPanel: React.FC = () => {
           <Typography.Text>{activePanel.title}</Typography.Text>
         </div>
         <div className={'grl-dg__panel__toolbar__actions'}>
-          <Tooltip title={'Close panel'}>
+          <Tooltip placement="topLeft" title={'Close panel'}>
             <Button
               size={'small'}
               type={'text'}


### PR DESCRIPTION
I noticed a problem with the position on the tooltip when hovering due to the position it was opened in.


https://github.com/user-attachments/assets/b83dfbdd-6039-47db-887c-60da1c20cd98


Also with the way the exports where changed in the package.json its no longer possible to import the component in a nextjs project without creating aliases in the webpack config. 

Adding require to the package.json solves that problem. It also provides better esm support 
