### PR TITLE
fix: add union for error and result, allowing both to be displayed

### DIFF
--- a/packages/jdm-editor/src/components/decision-graph/nodes/graph-node.tsx
+++ b/packages/jdm-editor/src/components/decision-graph/nodes/graph-node.tsx
@@ -161,8 +161,8 @@ export const GraphNode = React.forwardRef<HTMLDivElement, GraphNodeProps>(
           }
           status={match([nodeTrace, nodeError, displayError])
             .with([P._, P._, true], () => 'error' as const)
-            .with([P.not(P.nullish), P._, P._], () => 'success' as const)
             .with([P._, P.not(P.nullish), P._], () => 'error' as const)
+            .with([P.not(P.nullish), P._, P._], () => 'success' as const)
             .otherwise(() => undefined)}
           diffStatus={match([diff])
             .with([{ status: 'added' }], () => 'added' as const)

--- a/packages/jdm-editor/src/components/decision-graph/types/simulation.types.ts
+++ b/packages/jdm-editor/src/components/decision-graph/types/simulation.types.ts
@@ -1,7 +1,7 @@
 type Input = unknown;
 type Output = unknown;
 
-export type Simulation = { result?: SimulationOk } | { error?: SimulationError };
+export type Simulation = { result?: SimulationOk } & { error?: SimulationError };
 
 export type SimulationError = {
   title?: string;


### PR DESCRIPTION
# Display Both Error and Success States in Decision Graph
This PR modifies the decision graph visualization to support displaying both error and success states simultaneously, providing better visibility into the execution flow.

## Changes
🔄 Changed Simulation type to use intersection (&) instead of union (|) to allow both error and result states
🎨 Updated status matching logic in GraphNode to properly handle cases where both states are present
⚡️ Reordered pattern matching conditions to ensure correct precedence of error states over success states