### PR TITLE
Update table component to support hierarchical inputs and outputs

### DIFF
--- a/packages/jdm-editor/src/components/decision-table/table/table-head-cell.tsx
+++ b/packages/jdm-editor/src/components/decision-table/table/table-head-cell.tsx
@@ -208,6 +208,17 @@ export const TableHeadCellInputField: React.FC<TableHeadCellFieldProps> = ({ con
                         });
                       },
                     },
+                    {
+                      key: 'addChild',
+                      label: 'Add child column',
+                      onClick: () => {
+                        setDialog({
+                          type: 'add',
+                          columnType: 'inputs',
+                          item: schema,
+                        });
+                      },
+                    },
                   ],
                 }}
               >
@@ -301,6 +312,17 @@ export const TableHeadCellOutputField: React.FC<TableHeadCellFieldProps> = ({ co
                             danger: true,
                           },
                           onOk: () => tableActions.removeColumn('outputs', schema.id),
+                        });
+                      },
+                    },
+                    {
+                      key: 'addChild',
+                      label: 'Add child column',
+                      onClick: () => {
+                        setDialog({
+                          type: 'add',
+                          columnType: 'outputs',
+                          item: schema,
                         });
                       },
                     },

--- a/packages/jdm-editor/src/components/decision-table/table/table.tsx
+++ b/packages/jdm-editor/src/components/decision-table/table/table.tsx
@@ -88,6 +88,15 @@ export const Table: React.FC<TableProps> = ({ id, maxHeight }) => {
               minSize: minColWidth,
               size: colWidth,
               header: () => <TableHeadCellInputField schema={input} configurable={configurable} disabled={disabled} />,
+              columns: input.children?.map((child: any) => ({
+                accessorKey: child.id,
+                id: child.id,
+                minSize: minColWidth,
+                size: colWidth,
+                header: () => (
+                  <TableHeadCellInputField schema={child} configurable={configurable} disabled={disabled} />
+                ),
+              })),
             };
           }),
         ],
@@ -106,6 +115,15 @@ export const Table: React.FC<TableProps> = ({ id, maxHeight }) => {
               header: () => (
                 <TableHeadCellOutputField schema={output} configurable={configurable} disabled={disabled} />
               ),
+              columns: output.children?.map((child: any) => ({
+                accessorKey: child.id,
+                id: child.id,
+                minSize: minColWidth,
+                size: colWidth,
+                header: () => (
+                  <TableHeadCellOutputField schema={child} configurable={configurable} disabled={disabled} />
+                ),
+              })),
             };
           }),
         ],


### PR DESCRIPTION
Add support for hierarchical input and output columns in the decision table context.

* Add `children` property to `TableSchemaItem` type to support hierarchical structure.
* Update `createNewRule` and `createNewRules` functions to handle hierarchical columns.
* Add `addChildColumn` function to the context to allow adding new ranges in hierarchical columns.
* Update state management to handle hierarchical columns and dynamic range addition.

