### PR TITLE
bugfix: Fixed Null Exception When Editing Decision Table Node with null as default value.

### DIFF
--- a/packages/jdm-editor/src/components/decision-table/components/input-field-edit.tsx
+++ b/packages/jdm-editor/src/components/decision-table/components/input-field-edit.tsx
@@ -2,6 +2,7 @@ import { type Variable } from '@gorules/zen-engine-wasm';
 import { Button, Popover, Typography } from 'antd';
 import clsx from 'clsx';
 import { ChevronDownIcon } from 'lucide-react';
+import _defaultTo from 'lodash/defaultTo'
 import React, { useEffect, useRef, useState } from 'react';
 
 import type { CodeEditorRef } from '../../code-editor';
@@ -76,21 +77,21 @@ export const InputFieldEdit: React.FC<InputFieldEditProps> = ({
             e.stopPropagation();
             setOpen(false);
             if (!disabled && isSubmit) {
-              onChange?.(innerValue ?? '');
+              onChange?.(_defaultTo(innerValue, ""));
             }
           }}
         >
           <Typography.Text style={{ fontSize: 12, display: 'block', marginBottom: 2 }}>Input Field</Typography.Text>
           <CodeEditor
             ref={codeEditor}
-            value={innerValue}
+            value={_defaultTo(innerValue, "")}
             onChange={setInnerValue}
             variableType={variableType}
             disabled={disabled}
           />
           <div style={{ marginTop: 16 }}>
             <CodeEditorPreview
-              expression={innerValue ?? ''}
+              expression={_defaultTo(innerValue, "")}
               inputData={inputData}
               initial={referenceData ? { expression: referenceData.field, result: referenceData.value } : undefined}
             />
@@ -105,7 +106,7 @@ export const InputFieldEdit: React.FC<InputFieldEditProps> = ({
                   type='primary'
                   disabled={disabled}
                   onClick={() => {
-                    onChange?.(innerValue ?? '');
+                    onChange?.(_defaultTo(innerValue, ""));
                     setOpen(false);
                   }}
                 >

--- a/packages/jdm-editor/src/components/decision-table/components/input-field-edit.tsx
+++ b/packages/jdm-editor/src/components/decision-table/components/input-field-edit.tsx
@@ -1,8 +1,8 @@
 import { type Variable } from '@gorules/zen-engine-wasm';
 import { Button, Popover, Typography } from 'antd';
 import clsx from 'clsx';
+import _defaultTo from 'lodash/defaultTo';
 import { ChevronDownIcon } from 'lucide-react';
-import _defaultTo from 'lodash/defaultTo'
 import React, { useEffect, useRef, useState } from 'react';
 
 import type { CodeEditorRef } from '../../code-editor';

--- a/packages/jdm-editor/src/components/decision-table/components/input-field-edit.tsx
+++ b/packages/jdm-editor/src/components/decision-table/components/input-field-edit.tsx
@@ -77,21 +77,21 @@ export const InputFieldEdit: React.FC<InputFieldEditProps> = ({
             e.stopPropagation();
             setOpen(false);
             if (!disabled && isSubmit) {
-              onChange?.(_defaultTo(innerValue, ""));
+              onChange?.(_defaultTo(innerValue, ''));
             }
           }}
         >
           <Typography.Text style={{ fontSize: 12, display: 'block', marginBottom: 2 }}>Input Field</Typography.Text>
           <CodeEditor
             ref={codeEditor}
-            value={_defaultTo(innerValue, "")}
+            value={_defaultTo(innerValue, '')}
             onChange={setInnerValue}
             variableType={variableType}
             disabled={disabled}
           />
           <div style={{ marginTop: 16 }}>
             <CodeEditorPreview
-              expression={_defaultTo(innerValue, "")}
+              expression={_defaultTo(innerValue, '')}
               inputData={inputData}
               initial={referenceData ? { expression: referenceData.field, result: referenceData.value } : undefined}
             />
@@ -106,7 +106,7 @@ export const InputFieldEdit: React.FC<InputFieldEditProps> = ({
                   type='primary'
                   disabled={disabled}
                   onClick={() => {
-                    onChange?.(_defaultTo(innerValue, ""));
+                    onChange?.(_defaultTo(innerValue, ''));
                     setOpen(false);
                   }}
                 >


### PR DESCRIPTION
Hi team,

There is an issue when editing the Decision Table node with uploaded graph that has decision table node has input field's default value is `null`.

That will resolve this #229.

Please help me to take a look at it.

Thanks and have a nice day 🌞