### PR TITLE
Add Description field to expression entries similar to decision table

### DIFF
--- a/packages/jdm-editor/src/components/expression/context/expression-store.context.tsx
+++ b/packages/jdm-editor/src/components/expression/context/expression-store.context.tsx
@@ -21,6 +21,7 @@ export type ExpressionEntry = {
   id: string;
   key: string;
   value: string;
+  _description?: string;
   _diff?: DiffMetadata;
 };
 

--- a/packages/jdm-editor/src/components/expression/expression-item.tsx
+++ b/packages/jdm-editor/src/components/expression/expression-item.tsx
@@ -126,6 +126,18 @@ export const ExpressionItem: React.FC<ExpressionItemProps> = ({ expression, inde
           </div>
         </ExpressionItemContextMenu>
       </div>
+      <div className='expression-list-item__description'>
+        <DiffAutosizeTextArea
+          noStyle
+          placeholder='Description'
+          maxRows={10}
+          readOnly={permission !== 'edit:full' || disabled}
+          displayDiff={expression?._diff?.fields?._description?.status === 'modified'}
+          previousValue={expression?._diff?.fields?._description?.previousValue}
+          value={expression?._description || ''}
+          onChange={(e) => onChange({ _description: e.target.value })}
+        />
+      </div>
       <div className='expression-list-item__action'>
         <ConfirmAction iconOnly disabled={permission !== 'edit:full' || disabled} onConfirm={onRemove} />
         {isFocused && <LivePreview id={expression.id} value={expression.value} />}

--- a/packages/jdm-editor/src/components/expression/expression-list.tsx
+++ b/packages/jdm-editor/src/components/expression/expression-list.tsx
@@ -54,6 +54,9 @@ export const ExpressionList: React.FC<ExpressionListProps> = ({}) => {
           <Typography.Text type='secondary' className={'expression-list__item__th'}>
             Expression
           </Typography.Text>
+          <Typography.Text type='secondary' className={'expression-list__item__th expression-list__item__th--desc'}>
+            Description
+          </Typography.Text>
           <div />
         </div>
         {(expressions || []).map((expression, index) => (

--- a/packages/jdm-editor/src/components/expression/expression.scss
+++ b/packages/jdm-editor/src/components/expression/expression.scss
@@ -16,7 +16,7 @@
     background: var(--grl-color-bg-container);
     grid-auto-flow: column;
     align-items: flex-start;
-    grid-template-columns: 40px minmax(240px, 1.1fr) 3fr 40px;
+    grid-template-columns: 40px minmax(240px, 1.1fr) 3fr minmax(280px, 1.2fr) 40px;
 
     &:focus-within {
       box-shadow: 0 0 0 1px var(--grl-color-border);
@@ -138,6 +138,25 @@
     &__code {
       position: relative;
       font-size: 13px;
+      border-right: 1px solid var(--border-color);
+    }
+
+    &__description {
+      border-right: 1px solid var(--border-color);
+
+      [contenteditable] {
+        border: 0;
+        width: 100%;
+        background-color: transparent;
+        padding: $pv $ph;
+        border-radius: 0;
+        line-height: 1.5em;
+        font-size: 13px;
+
+        &:focus {
+          box-shadow: none !important;
+        }
+      }
     }
 
     &__value {

--- a/packages/jdm-editor/src/helpers/schema.ts
+++ b/packages/jdm-editor/src/helpers/schema.ts
@@ -179,6 +179,7 @@ export const expressionNodeSchema = z
           id,
           key: z.string().default(''),
           value: z.string().default(''),
+          _description: z.string().default(''),
         }),
       ),
       passThrough: z


### PR DESCRIPTION
<img width="1908" height="695" alt="image" src="https://github.com/user-attachments/assets/c00101ac-3960-42c5-bace-fb77a836313c" />

## Why
Expression nodes often contain complex business logic (data transformations, aggregations,       
conditional calculations). When reviewing or debugging a graph, it's hard to remember what each  
expression does without reading the code.             

## Changes
  - Added `_description?: string` to `ExpressionEntry` type
  - Added Description column in expression list (header + input field per row)
  - Updated schema validation for expression node expressions
  - Added separator border between expression code and description
  - Increased description column width (min 280px, flex 1.2fr)
                                                                                                   
Tests
  - [x] Build passes
  - [x] TypeScript typecheck passes
  - [x] Lint passes
  - [x] Description field renders in Storybook
  - [x] Description is editable with `edit:full` permission
  - [x] Description is read-only with `view`/`edit:values` permission
