### PR TITLE
[BUG FIX]: preserve field names without whitespace on decision table column…

### DIFF
--- a/packages/jdm-editor/src/components/decision-table/dt-command-bar.tsx
+++ b/packages/jdm-editor/src/components/decision-table/dt-command-bar.tsx
@@ -45,11 +45,14 @@ export const DecisionTableCommandBar: React.FC = () => {
         return {
           id: newId,
           name: item.label,
-          field: item.value
-            ?.replace(/[^a-zA-Z0-9\s._]/g, '')
-            .trim()
-            .replace(/\s+/g, '.')
-            .toLowerCase(),
+          field:
+            item.value && !/\s/.test(item.value.trim())
+              ? item.value.trim()
+              : item.value
+                  ?.replace(/[^a-zA-Z0-9\s._]/g, '')
+                  .trim()
+                  .replace(/\s+/g, '.')
+                  .toLowerCase(),
           fieldType: existing?.fieldType,
           defaultValue: existing?.defaultValue,
         };
@@ -66,14 +69,17 @@ export const DecisionTableCommandBar: React.FC = () => {
         return {
           id: newId,
           name: item.label,
-          field: item.value
-            ?.replace(/[^a-zA-Z0-9\s._]/g, '')
-            .trim()
-            .split(/\s+/)
-            .map((word, index) =>
-              index === 0 ? word.toLowerCase() : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
-            )
-            .join(''),
+          field:
+            item.value && !/\s/.test(item.value.trim())
+              ? item.value.trim()
+              : item.value
+                  ?.replace(/[^a-zA-Z0-9\s._]/g, '')
+                  .trim()
+                  .split(/\s+/)
+                  .map((word, index) =>
+                    index === 0 ? word.toLowerCase() : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
+                  )
+                  .join(''),
           outputFieldType: existing?.outputFieldType,
           defaultValue: existing?.defaultValue,
         };


### PR DESCRIPTION
 When importing into a decision table node from Excel, the column field mapping in DecisionTableCommandBar.handleDataMapping it strips any characters outside the regex [a-zA-Z0-9\s._] and then lowercases the field mappings. In the case the field already has camel casing and has no spaces the result for input columns it breaks mappings for between the column and an input json path. A similar thing happens for the output columns

For example:
  - customer.riskScore → customer.riskscore (casing lost, so it no longer matches the actual input field)
  - Expressions containing characters like $ or [0] have those characters stripped entirely

  As a result, re-importing a sheet could silently break the binding between columns and the fields they reference.

  This fix only applies the normalization when the mapped value actually contains whitespace (i.e., it's a human-readable label that needs converting into a field name). If the trimmed value has nowhitespace, treat it as an already-valid field expression and use it as-is.

 This applies to both input and output column mapping.
