### PR TITLE
feat(canvas): enhance navigation UX and cross-platform shortcuts

### DIFF
--- a/packages/jdm-editor/src/components/decision-graph/graph/graph.tsx
+++ b/packages/jdm-editor/src/components/decision-graph/graph/graph.tsx
@@ -1,5 +1,5 @@
-import { CompressOutlined, LeftOutlined, RightOutlined, WarningOutlined } from '@ant-design/icons';
-import { App, Button, Typography, message, notification } from 'antd';
+import { CompressOutlined, LeftOutlined, RightOutlined, WarningOutlined, QuestionCircleOutlined } from '@ant-design/icons';
+import { App, Button, Typography, message, notification, Popover } from 'antd';
 import clsx from 'clsx';
 import equal from 'fast-deep-equal';
 import React, { type MutableRefObject, forwardRef, useImperativeHandle, useMemo, useRef, useState } from 'react';
@@ -12,6 +12,7 @@ import ReactFlow, {
   getOutgoers,
   useEdgesState,
   useNodesState,
+  Panel,
 } from 'reactflow';
 import 'reactflow/dist/style.css';
 import { P, match } from 'ts-pattern';
@@ -22,7 +23,6 @@ import {
   type ExposedStore,
   useDecisionGraphActions,
   useDecisionGraphListeners,
-  useDecisionGraphRaw,
   useDecisionGraphReferences,
   useDecisionGraphState,
 } from '../context/dg-store.context';
@@ -94,7 +94,6 @@ export const Graph = forwardRef<GraphRef, GraphProps>(function GraphInner({ reac
 
   const initialViewport = useRef<Viewport | undefined>(undefined);
 
-  const raw = useDecisionGraphRaw();
   const registry = useSerializerRegistry();
   const graphActions = useDecisionGraphActions();
   const graphReferences = useDecisionGraphReferences((s) => s);
@@ -396,7 +395,7 @@ export const Graph = forwardRef<GraphRef, GraphProps>(function GraphInner({ reac
       className={clsx(['tab-content', className])}
       tabIndex={0}
       onKeyDown={(e) => {
-        if (e.key === 'v' && e.metaKey && !disabled) {
+        if (e.key === 'v' && (e.ctrlKey || e.metaKey) && !disabled) {
           graphActions.pasteNodes();
         }
       }}
@@ -416,7 +415,7 @@ export const Graph = forwardRef<GraphRef, GraphProps>(function GraphInner({ reac
             const [nodes] = nodesState;
             const [edges] = edgesState;
 
-            if (e.key === 'c' && e.metaKey) {
+            if (e.key === 'c' && (e.ctrlKey || e.metaKey)) {
               const selectedNodeIds = nodesState[0].filter((n) => n.selected).map(({ id }) => id);
               if (selectedNodeIds.length === 0) {
                 return;
@@ -424,7 +423,7 @@ export const Graph = forwardRef<GraphRef, GraphProps>(function GraphInner({ reac
 
               graphActions.copyNodes(selectedNodeIds);
               e.preventDefault();
-            } else if (e.key === 'd' && e.metaKey) {
+            } else if (e.key === 'd' && (e.ctrlKey || e.metaKey)) {
               if (!disabled) {
                 const selectedNodeIds = nodes.filter((n) => n.selected).map(({ id }) => id);
                 if (selectedNodeIds.length === 0) {
@@ -434,7 +433,7 @@ export const Graph = forwardRef<GraphRef, GraphProps>(function GraphInner({ reac
                 graphActions.duplicateNodes(selectedNodeIds);
               }
               e.preventDefault();
-            } else if (e.key === 'Backspace') {
+            } else if (e.key === 'Backspace' || e.key === 'Delete') {
               if (!disabled) {
                 const selectedNodes = nodes.filter((n) => n.selected);
                 const selectedEdges = edges.filter((e) => e.selected);
@@ -488,13 +487,17 @@ export const Graph = forwardRef<GraphRef, GraphProps>(function GraphInner({ reac
               snapGrid={[5, 5]}
               minZoom={0.25}
               selectionMode={SelectionMode.Partial}
+              selectionOnDrag={true}
+              panOnScroll={true}
+              panOnDrag={[1, 2]}
+              multiSelectionKeyCode={['Meta', 'Control', 'Shift']}
               nodeTypes={nodeTypes}
               edgeTypes={edgeTypes}
               onDrop={onDrop}
               onDragOver={onDragOver}
               onConnect={onConnect}
               isValidConnection={isValidConnection}
-              proOptions={reactFlowProOptions}
+              proOptions={{ ...reactFlowProOptions }}
               nodesConnectable={!disabled}
               nodesDraggable={!disabled}
               edgesUpdatable={!disabled}
@@ -514,6 +517,40 @@ export const Graph = forwardRef<GraphRef, GraphProps>(function GraphInner({ reac
                 </ControlButton>
               </Controls>
               <Background id={id} color='var(--grl-color-border)' gap={20} />
+              <Panel position='top-right' style={{ marginTop: 10, marginRight: 10 }}>
+                <Popover
+                  placement='bottomRight'
+                  title='Keyboard Shortcuts'
+                  content={
+                    <div style={{ fontSize: 13, lineHeight: '2' }}>
+                      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 24 }}>
+                        <span style={{ fontWeight: 500 }}>Pan</span>
+                        <span style={{ color: 'var(--grl-color-text-secondary)' }}>
+                          <kbd>Space</kbd> + Drag <i>or</i> 2-finger scroll
+                        </span>
+                      </div>
+                      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 24 }}>
+                        <span style={{ fontWeight: 500 }}>Zoom</span>
+                        <span style={{ color: 'var(--grl-color-text-secondary)' }}>
+                          <kbd>Ctrl</kbd> + Scroll <i>or</i> Pinch
+                        </span>
+                      </div>
+                      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 24 }}>
+                        <span style={{ fontWeight: 500 }}>Select</span>
+                        <span style={{ color: 'var(--grl-color-text-secondary)' }}>Drag</span>
+                      </div>
+                      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 24 }}>
+                        <span style={{ fontWeight: 500 }}>Multi-select</span>
+                        <span style={{ color: 'var(--grl-color-text-secondary)' }}>
+                          <kbd>Ctrl</kbd> + Click
+                        </span>
+                      </div>
+                    </div>
+                  }
+                >
+                  <Button type='text' shape='circle' icon={<QuestionCircleOutlined />} style={{ color: 'var(--grl-color-text-secondary)', backgroundColor: 'var(--grl-color-bg-container)' }} />
+                </Popover>
+              </Panel>
             </ReactFlow>
           </div>
         </div>

--- a/packages/jdm-editor/src/components/decision-graph/nodes/graph-node.tsx
+++ b/packages/jdm-editor/src/components/decision-graph/nodes/graph-node.tsx
@@ -111,13 +111,6 @@ export const GraphNode = React.forwardRef<HTMLDivElement, GraphNodeProps>(
         className={clsx('grl-graph-node', className)}
         style={{ minWidth: 220, maxWidth: 220 }}
         ref={ref}
-        onClick={(event) => {
-          const isToggle = match(navigator.platform.includes('Mac'))
-            .with(true, () => event.metaKey)
-            .otherwise(() => event.ctrlKey);
-
-          graphActions.triggerNodeSelect(id, isToggle ? 'toggle' : 'only');
-        }}
       >
         {handleLeft && (
           <Handle

--- a/packages/jdm-editor/src/components/decision-table/table/table.tsx
+++ b/packages/jdm-editor/src/components/decision-table/table/table.tsx
@@ -8,7 +8,11 @@ import equal from 'fast-deep-equal/es6/react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { z } from 'zod';
 
-import { useDecisionTableActions, useDecisionTableListeners, useDecisionTableState } from '../context/dt-store.context';
+import {
+  useDecisionTableActions,
+  useDecisionTableListeners,
+  useDecisionTableState,
+} from '../context/dt-store.context';
 import { TableContextMenu } from './table-context-menu';
 import { TableDefaultCell } from './table-default-cell';
 import {
@@ -153,9 +157,9 @@ export const Table: React.FC<TableProps> = ({ id, maxHeight, scrollContainerRef,
     ...(!id
       ? {}
       : {
-          state: { columnSizing },
-          onColumnSizingChange: setColumnSizing,
-        }),
+        state: { columnSizing },
+        onColumnSizingChange: setColumnSizing,
+      }),
   });
 
   const tableContainerRef = useRef<HTMLDivElement>(null);
@@ -309,14 +313,12 @@ const TableBody = React.forwardRef<HTMLTableSectionElement, TableBodyProps>(
 
       if (e.code === 'ArrowUp' && (e.metaKey || e.altKey)) {
         if (cursor) tableActions.addRowAbove(cursor.y);
-      }
-      if (e.code === 'ArrowDown' && (e.metaKey || e.altKey)) {
+      } else if (e.code === 'ArrowDown' && (e.metaKey || e.altKey)) {
         if (cursor) tableActions.addRowBelow(cursor.y);
-      }
-      if (e.code === 'Backspace' && (e.metaKey || e.altKey)) {
+      } else if (e.code === 'Backspace' && (e.metaKey || e.altKey)) {
         if (cursor) tableActions.removeRow(cursor.y);
       }
-    }, []);
+    }, [cursor, tableActions, disabled]);
 
     return (
       <tbody ref={ref} {...props} onKeyDown={onKeyDown}>


### PR DESCRIPTION
Hi team! 👋 
I really love using JDM Editor and noticed a few areas where the canvas navigation could feel a bit more native to Windows/Linux users and standard design tools (like Figma). 
This PR introduces several UX improvements to the Decision Graph canvas to provide a smoother interaction experience.
## Changes Made
- **Figma-like Navigation**: Enabled `panOnScroll`, `selectionOnDrag`, and `panOnDrag={[1, 2]}`. Users can now easily pan using the middle mouse button, right-click, or two-finger scroll.
- **Cross-Platform Copy/Paste**: Fixed the copy (`Ctrl/Cmd + C`) and paste (`Ctrl/Cmd + V`) shortcuts to explicitly support Windows and Linux by listening to both `ctrlKey` and `metaKey`.
- **Multi-select Standardization**: Switched to native React Flow multi-selection support using `multiSelectionKeyCode={['Meta', 'Control', 'Shift']}` and removed redundant manual click logic.
- **Cross-Platform Node Deletion**: Added support for the `Delete` key alongside `Backspace`, allowing Windows and Linux users to delete nodes naturally.
- **Keyboard Shortcuts Onboarding**: Added a clean, non-intrusive `Popover` (Ant Design) in the top-right corner containing a list of keyboard shortcuts for easy user reference.

## Visual Proof
<img width="2483" height="1328" alt="Screenshot from 2026-08-25 00-35-32" src="https://github.com/user-attachments/assets/f520156c-7bfc-4504-91b2-2253b24880a8" />


<img width="2685" height="1480" alt="Screenshot from 2026-08-25 00-26-35" src="https://github.com/user-attachments/assets/150798b2-f372-4110-a27d-72dda4647492" />


<img width="2685" height="1480" alt="Screenshot from 2026-08-25 00-27-11" src="https://github.com/user-attachments/assets/4dc707b0-be1e-4f4e-9278-3d0edc273e3f" />
